### PR TITLE
Suggested addition to "text as mediator"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ _Pull requests welcome!_
 | Title | Description | Code |
 |-------|-------------|------|
 | [Adapting Text Embeddings for Causal Inference](https://arxiv.org/pdf/1905.12741.pdf) <br> Victor Veitch, Dhanya Sridhar, and David Blei      |  (also text as confounder) Adapts BERT embeddings for causal inference by predicting propensity scores and potential outcomes alongside masked language modeling objective.      |  [tensorflow](https://github.com/blei-lab/causal-text-embeddings) <br> [pytorch](https://github.com/rpryzant/causal-bert-pytorch)    |
-|       |             |      |
+| [Operationalizing Complex Causes: A Pragmatic View of Mediation](https://arxiv.org/abs/2106.05074) <br> Limor Gultchin, David Watson, Matt Kusner and Ricardo Silva| (can also be viewed as text as treatment) Develops a notion of pragmatic mediation which helps make causel effect estimation when complex objects, such as text, image or genomics are involved, across various intervention regimes. Identification of prgamtic mediators has an interpretability benefit which could guide the development of new interventions. | [git](https://github.com/limorigu/ComplexCauses) |
 
 ## Text as outcome
 


### PR DESCRIPTION
Hi all,

Really nice repo, thanks for putting it together! Wanted to suggest an addition of our work from ICML 2021, looking at causal effect estimation with pragmatic mediation, with text being one of the main motivating examples. It is also one of three application areas we looked at. I completely understand if you'd think it's not focused enough on NLP for this repo, but thought it was worth a suggestion. Feel free to reject the addition if you think it's out of scope.

Additionally, we recently looked at suggested a unifying framework for XAI, across the main approaches to ML interpretability (https://arxiv.org/abs/2103.14651). It is framed in causal language but is rather flexible, and quite a few of the examples we looked at were text-based. I did not add it to the README.md yet, as I think this one might be even more out of scope, but thought it was worth mentioning as well in case it piqued your interest. 

Regardless of your decision on this -- thanks so much for creating this repo, it's a great resource. Keep up the good work!